### PR TITLE
Fix bug causing MC output files to be read from incorrect directory.

### DIFF
--- a/R/util.R
+++ b/R/util.R
@@ -193,7 +193,7 @@ load_matching_mcout <- function(runid, dir='.', filestem='hectorcal', niter=NA)
                          'mcrslt\\.rds')
 
 
-    files <- list.files(dir, fileregexp)
+    files <- list.files(dir, fileregexp, full.names = TRUE)
     structure(lapply(files, readRDS), names=files)
 }
 


### PR DESCRIPTION
So counterintuitive that `list.files` doesn't include the directory by default.  Anyway, this is a tiny one-line fix, so I'm going to just merge it.
