### PR TITLE
Add prior parameter for heat flux sigma.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: hectorcal
 Title: Support code for the Hector calibration project
-Version: 0.2.0
+Version: 0.2.1
 Authors@R: c(person("Robert", "Link", email="robert.link@pnnl.gov", role = "aut"),
           person("Kalyn", "Dorheim", 
           email = "kalyn.dorheim@pnnl.gov", 

--- a/R/likelihood.R
+++ b/R/likelihood.R
@@ -61,6 +61,7 @@ build_mcmc_post <- function(comp_data, inifiles,
         q10mu=2.0, q10sig=2.0,
         c0mu=285, c0sig=14.0,
         sigtscale=1.0,
+        sighfscale=1.0,
         sigco2scale=10.0,
         sigpscale=1.0,
         sigmscale=0.25)


### PR DESCRIPTION
This was supposed to be in the original sigfit PR, but it got left out by mistake.  Version incremented to 0.2.1 so as to distinguish it from the version that's missing it.
